### PR TITLE
Performance feedback

### DIFF
--- a/src/application.js
+++ b/src/application.js
@@ -1,0 +1,64 @@
+/* @flow */
+
+import {Task} from "./task"
+import {mailbox, map, reductions} from "./signal"
+import {Effects} from "./effects"
+import {root} from "./dom"
+
+/*::
+import type {Mailbox, Signal} from "./signal"
+import type {BeginnerConfiguration, AdvancedConfiguration, Application} from "./application"
+*/
+
+const first = /*::<a, b>*/ (xs/*:[a, b]*/)/*:a*/ => xs[0]
+const second = /*::<a, b>*/ (xs/*:[a, b]*/)/*:b*/ => xs[1]
+
+
+export const beginner = /*::<model, action>*/
+  (configuration/*:BeginnerConfiguration<model, action>*/)/*:AdvancedConfiguration<model, action, void>*/ =>
+  ( { flags: void(0)
+    , init: _ =>
+      [ configuration.model
+      , Effects.none
+      ]
+    , update: (model, action) =>
+      [ configuration.update(model, action)
+      , Effects.none
+      ]
+    , view: configuration.view
+    }
+  )
+
+export const start = /*::<model, action, flags>*/
+  (configuration/*:AdvancedConfiguration<model, action, flags>*/)/*:Application<model, action>*/ => {
+    const {init, view, update, flags} = configuration
+    // We don't have a value of `action` type there for we can not
+    // create a `Mailbox<action>`. Elm works around that by defining
+    // Mailbox<Array<action>> and starts with `[]`, but boxing every action
+    // is hard to justify just to make type system happy. So instead we just
+    // start with `null`.
+    // @FlowIgnore:
+    const {address, signal} = mailbox(({}/*:action*/))
+    const step =
+      ( [model, _]
+      , action
+      ) =>
+      update(model, action)
+
+    const display =
+      (model) =>
+      root(view, model, address)
+
+    const steps =
+      reductions(step, init(flags), signal)
+
+    const model = map(first, steps)
+    const application =
+      { address
+      , model
+      , task: map(second, steps)
+      , view: map(display, model)
+      }
+
+    return application
+  }

--- a/src/dom.js
+++ b/src/dom.js
@@ -1,0 +1,131 @@
+/* @flow */
+
+/*::
+import type {Text, Key, TagName, PropertyDictionary} from "./core"
+import type {VirtualText, VirtualNode, VirtualTree, LazyTree, Thunk} from "./core"
+import type {Driver} from "./driver"
+import type {Address} from "./signal"
+
+export type {Text, Key, TagName}
+*/
+
+let driver/*:?Driver*/ = null
+
+class VirtualRoot /*::<model, action>*/ {
+  /*::
+  $type: "VirtualRoot";
+
+  view: (model:model, address:Address<action>) => VirtualTree;
+  model: model;
+  address: Address<action>;
+  */
+  constructor(
+    view/*:(model:model, address:Address<action>) => VirtualTree*/
+  , model/*:model*/
+  , address/*:Address<action>*/
+  ) {
+    this.view = view
+    this.model = model
+    this.address = address
+  }
+  renderWith(current/*:Driver*/) {
+    const previous = driver
+    driver = current
+
+    try {
+      driver.render(this.view(this.model, this.address))
+    } finally {
+      driver = previous
+    }
+  }
+}
+VirtualRoot.prototype.$type = "VirtualRoot"
+
+export class LazyNode {
+  /*::
+  $type: "LazyTree";
+
+  tagName: TagName;
+  properties: ?PropertyDictionary;
+  children: ?Array<VirtualTree>;
+  key: ?Key;
+  namespace: string;
+  */
+  constructor(tagName/*:TagName*/, properties/*:?PropertyDictionary*/, children/*:?Array<VirtualTree>*/) {
+    this.tagName = tagName
+    this.properties = properties
+    this.children = children
+    this.key = properties == null ? null : properties.key
+  }
+  force()/*:VirtualNode*/ {
+    if (driver == null) {
+      throw TypeError('LazyTree may only be forced from with in the Root.renderWith(driver) call')
+    }
+
+    return driver.node(this.tagName, this.properties, this.children)
+  }
+}
+LazyNode.prototype.$type = "LazyTree";
+
+class LazyThunk {
+  /*::
+  $type: "LazyTree";
+
+  key: Key;
+  view: Function;
+  args: Array<any>;
+  */
+  constructor(key/*:Key*/, view/*:Function*/, args/*:Array<any>*/) {
+    this.key = key
+    this.view = view
+    this.args = args
+  }
+  force()/*:Thunk*/ {
+    if (driver == null) {
+      throw TypeError('LazyTree may only be forced from with in the Root.renderWith(driver) call')
+    }
+
+    return driver.thunk(this.key, this.view, ...this.args)
+  }
+}
+LazyThunk.prototype.$type = "LazyTree";
+
+export const root = /*::<model, action>*/
+  ( view/*:(model:model, address:Address<action>) => VirtualTree*/
+  , model/*:model*/
+  , address/*:Address<action>*/
+  )/*:VirtualRoot*/ =>
+  new VirtualRoot
+  ( view
+  , model
+  , address
+  )
+
+export const text =
+  (content/*:Text*/)/*:Text | VirtualText*/ =>
+  ( driver == null
+  ? content
+  : driver.text == null
+  ? content
+  : driver.text(content)
+  )
+
+export const node =
+  ( tagName/*:TagName*/
+  , properties/*:?PropertyDictionary*/
+  , children/*:?Array<VirtualTree>*/
+  )/*:VirtualNode | LazyTree<VirtualNode>*/ =>
+  ( driver == null
+  ? new LazyNode(tagName, properties, children)
+  : driver.node(tagName, properties, children)
+  )
+
+export const thunk = /*::<a, b, c, d, e, f, g, h, i, j>*/
+  ( key/*:string*/
+  , view/*:(a:a, b:b, c:c, d:d, e:e, f:f, g:g, h:h, i:i, j:j) => VirtualTree*/
+  , ...args/*:Array<any>*/
+  )/*:Thunk | LazyTree<Thunk>*/ =>
+  ( driver == null
+  ? new LazyThunk(key, view, args)
+  : driver.thunk(key, view, ...args)
+  )

--- a/src/effects.js
+++ b/src/effects.js
@@ -1,0 +1,209 @@
+/* @flow */
+
+import {Task} from "./task"
+
+/*::
+import type {Never} from "./effects"
+import type {Address} from "./signal"
+*/
+
+const raise =
+  error => {
+    throw Error(`Effects should be created from task that never fail but it did fail with error ${error}`)
+  }
+
+const ignore =
+  _ =>
+  void(0)
+
+const nil =
+  Task.succeed(void(0))
+
+const never =
+  new Task((succeed, fail) => void(0))
+
+export class Effects /*::<a>*/ {
+  static task /*::<a>*/(task/*:Task<Never, a>*/)/*:Effects<a>*/ {
+    return new Effects(task)
+  }
+  static tick /*::<a>*/(tag/*:(time:Time) => a*/)/*:Effects<a>*/ {
+    return new Tick(tag)
+  }
+  static receive /*::<a>*/(action/*:a*/)/*:Effects<a>*/ {
+    const fx =
+      new Effects
+      ( new Task
+        ( (succeed, fail) =>
+          void
+          ( Promise
+            .resolve(action)
+            .then(succeed, fail)
+          )
+        )
+      )
+    return fx
+  }
+  static batch /*::<a>*/(effects/*:Array<Effects<a>>*/)/*:Effects<a>*/ {
+    return new Batch(effects)
+  }
+  static driver /*::<a>*/(address/*:Address<a>*/)/*:(fx:Effects<a>) => void*/ {
+    return fx => {
+      if (!(fx instanceof None)) {
+        Task.fork(fx.send(address), ignore, raise)
+      }
+    }
+  }
+  /*::
+  static none:Effects<any>;
+  task: Task<Never, a>;
+  */
+  constructor(task/*:Task<Never, a>*/) {
+    this.task = task
+  }
+  map/*::<b>*/(f/*:(a:a)=>b*/)/*:Effects<b>*/ {
+    return new Effects(this.task.map(f))
+  }
+  send(address/*:Address<a>*/)/*:Task<Never, void>*/ {
+    return this.task.chain(value => Task.send(address, value))
+  }
+}
+
+class None /*::<a>*/ extends Effects /*::<any>*/ {
+  constructor() {
+    super(never)
+  }
+  map/*::<b>*/(f/*:(a:a)=>b*/)/*:Effects<b>*/ {
+    return Effects.none
+  }
+  send(address/*:Address<a>*/)/*:Task<Never, void>*/ {
+    return nil
+  }
+}
+Effects.none = new None()
+
+class Batch /*::<a>*/ extends Effects /*::<a>*/ {
+  /*::
+  effects: Array<Effects<a>>;
+  */
+  constructor(effects/*:Array<Effects<a>>*/) {
+    super(never)
+    this.effects = effects
+  }
+  map/*::<b>*/(f/*:(a:a)=>b*/)/*:Effects<b>*/ {
+    return new Batch(this.effects.map(effect => effect.map(f)))
+  }
+  send(address/*:Address<a>*/)/*:Task<Never, void>*/ {
+    return new Task((succeed, fail) => {
+      const {effects} = this
+      const count = effects.length
+      let index = 0
+      while (index < count) {
+        const effect = effects[index]
+        if (!(effect instanceof None)) {
+          Task.fork(effect.send(address), ignore, raise)
+        }
+
+        index = index + 1
+      }
+      succeed(void(0))
+    })
+  }
+}
+
+
+class Tick /*::<a>*/ extends Effects /*::<a>*/ {
+  /*::
+  tag: (time:Time) => a;
+  */
+  constructor(tag/*:(time:Time) => a*/) {
+    super(never)
+    this.tag = tag
+  }
+  map/*::<b>*/(f/*:(a:a)=>b*/)/*:Effects<b>*/ {
+    return new Tick((time/*:Time*/) => f(this.tag(time)))
+  }
+  send(address/*:Address<a>*/)/*:Task<Never, void>*/ {
+    const task =
+      new Task
+      ( (succeed, fail) =>
+        animationScheduler.schedule(time => succeed(this.tag(time)))
+      )
+      .chain(action => Task.send(address, action))
+    return task
+  }
+}
+
+// Invariants:
+// 1. In the NO_REQUEST state, there is never a scheduled animation frame.
+// 2. In the PENDING_REQUEST and EXTRA_REQUEST states, there is always exactly
+// one scheduled animation frame.
+const NO_REQUEST = 0
+const PENDING_REQUEST = 1
+const EXTRA_REQUEST = 2
+
+
+/*::
+type Time = number
+type State = 0 | 1 | 2
+*/
+
+class AnimationScheduler {
+  /*::
+  state: State;
+  requests: Array<(time:Time) => any>;
+  execute: (time:Time) => void;
+  */
+  constructor() {
+    this.state = NO_REQUEST
+    this.requests = []
+    this.execute = this.execute.bind(this)
+  }
+  schedule(request) {
+    if (this.state === NO_REQUEST) {
+      window.requestAnimationFrame(this.execute)
+    }
+
+    this.requests.push(request)
+    this.state = PENDING_REQUEST
+  }
+  execute(time/*:Time*/)/*:void*/ {
+    switch (this.state) {
+      case NO_REQUEST:
+        // This state should not be possible. How can there be no
+        // request, yet somehow we are actively fulfilling a
+        // request?
+        throw Error(`Unexpected frame request`)
+      case PENDING_REQUEST:
+        // At this point, we do not *know* that another frame is
+        // needed, but we make an extra frame request just in
+        // case. It's possible to drop a frame if frame is requested
+        // too late, so we just do it preemptively.
+        window.requestAnimationFrame(this.execute)
+        this.state = EXTRA_REQUEST
+        this.dispatch(this.requests.splice(0), 0, time)
+        break
+      case EXTRA_REQUEST:
+        // Turns out the extra request was not needed, so we will
+        // stop requesting. No reason to call it all the time if
+        // no one needs it.
+        this.state = NO_REQUEST
+        break
+    }
+  }
+  dispatch(requests, index, time) {
+    const count = requests.length
+    try {
+      while (index < count) {
+        const request = requests[index]
+        index = index + 1
+        request(time)
+      }
+    } finally {
+      if (index < count) {
+        this.dispatch(requests, index, time)
+      }
+    }
+  }
+}
+
+const animationScheduler = new AnimationScheduler()

--- a/src/html.js
+++ b/src/html.js
@@ -1,0 +1,28 @@
+/* @noflow */
+
+import {node} from "./dom"
+/*::
+import type {Html, element} from "./html"
+*/
+
+export const html/*:Html*/ = Object.create(null);
+
+["a","abbr","address","area","article","aside","audio","b","base","bdi",
+ "bdo","big","blockquote","body","br","button","canvas","caption","cite",
+ "code","col","colgroup","data","datalist","dd","del","details","dfn",
+ "dialog","div","dl","dt","em","embed","fieldset","figcaption","figure",
+ "footer","form","h1","h2","h3","h4","h5","h6","head","header","hr","html",
+ "i","iframe","img","input","ins","kbd","keygen","label","legend","li","link",
+ "main","map","mark","menu","menuitem","meta","meter","nav","noscript",
+ "object","ol","optgroup","option","output","p","param","picture","pre",
+ "progress","q","rp","rt","ruby","s","samp","script","section","select",
+ "small","source","span","strong","style","sub","summary","sup","table",
+ "tbody","td","textarea","tfoot","th","thead","time","title","tr","track",
+ "u","ul","var","video","wbr","circle","clipPath","defs","ellipse","g","line",
+ "linearGradient","mask","path","pattern","polygon","polyline","radialGradient",
+ "rect","stop","svg","text","tspan"].forEach(tagName => {
+    const element/*:element*/ = (properties, children) =>
+      node(tagName, properties, children)
+
+    html[tagName] = element
+});

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,18 @@
+/* @flow */
+
+export {thunk, node, text} from "./dom"
+export {html} from "./html"
+export {forward, mailbox} from "./signal"
+export {start, beginner} from "./application"
+export {Effects} from "./effects"
+export {Task} from "./task"
+
+/*::
+export type {Address, Mailbox, Signal} from "./signal"
+export type {Key, TagName, Text, PropertyDictionary, VirtualText, VirtualNode, Thunk, Widget, LazyTree, VirtualTree} from "./core"
+export type {VirtualRoot} from "./driver"
+export type {Application, AdvancedConfiguration, BeginnerConfiguration} from "./application"
+export type {Init, Update, View} from "./application"
+export type {DOM} from "./dom"
+export type {Never} from "./effects"
+*/

--- a/src/signal.js
+++ b/src/signal.js
@@ -1,0 +1,186 @@
+/* @flow */
+
+
+/*::
+import type {Address, Signal, Mailbox} from "./signal"
+import type {Translate, Reducer, AddressBook} from "./signal"
+
+export type {Signal, Address, Mailbox}
+export type {Translate, Reducer, AddressBook}
+*/
+
+class Input /*::<a>*/ {
+  /*::
+  $type: "Signal.Signal";
+  value: a;
+  addressBook: ?AddressBook<a>;
+  isBlocked: boolean;
+  queue: ?Array<a>;
+  address: ?Address<a>;
+  */
+  static Address /*::<message>*/(signal/*:Input<message>*/)/*:Address<message>*/{
+    if (signal.address == null) {
+      signal.address = signal.receive.bind(signal)
+      // TODO: Submit a bug for flow as return here and else clause is
+      // redundunt.
+      return signal.address
+    } else {
+      return signal.address
+    }
+  }
+  static notify(message/*:a*/, addressBook/*:AddressBook<a>*/, from/*:number*/, to/*:number*/)/*:void*/ {
+    try {
+      while (from < to) {
+        const address = addressBook[from]
+        if (address != null) {
+          address(message)
+        }
+        from = from + 1
+      }
+    } finally {
+      if (from < to) {
+        Input.notify(message, addressBook, from + 1, to)
+      }
+    }
+  }
+  static connect(signal/*:Input<a>*/, address/*:Address<a>*/) {
+    if (signal.addressBook == null) {
+      signal.addressBook = [address]
+    } else {
+      // TODO: Submit a flow bug that seems to occur if observers aren't copyied
+      // presumably because it assumes that `this.observer.indexOf(observer)`
+      // may mutate this.
+      const addressBook = signal.addressBook
+      if (addressBook.indexOf(address) < 0) {
+        addressBook.push(address)
+      }
+    }
+  }
+  constructor(value/*:a*/) {
+    this.value = value
+    this.isBlocked = false
+
+    this.addressBook = null
+    this.queue = null
+    this.address = null
+  }
+  receive(value/*:a*/) {
+    // If signal is blocked queue transaction to be processed once it is
+    // unblocked.
+    if (this.isBlocked) {
+      if (this.queue == null) {
+        this.queue = [value]
+      } else {
+        this.queue.push(value)
+      }
+    } else {
+      this.isBlocked = true
+      try {
+        this.value = value
+
+        if (this.addressBook != null) {
+          const addressBook = this.addressBook
+          Input.notify(value, addressBook, 0, addressBook.length)
+        }
+      } finally {
+        this.isBlocked = false
+        if (this.queue != null && this.queue.length > 0) {
+          this.receive(value = this.queue.shift())
+        }
+      }
+    }
+  }
+  subscribe(address/*:Address<a>*/)/*:void*/ {
+    Input.connect(this, address)
+    address(this.value)
+  }
+  connect(address/*:Address<a>*/) {
+    if (this.addressBook == null) {
+      this.addressBook = [address]
+    } else {
+      // TODO: Submit a flow bug that seems to occur if observers aren't copyied
+      // presumably because it assumes that `this.observer.indexOf(observer)`
+      // may mutate this.
+      const addressBook = this.addressBook
+      if (addressBook.indexOf(address) < 0) {
+        addressBook.push(address)
+      }
+    }
+  }
+}
+Input.prototype.$type = "Signal.Signal"
+
+class Inbox /*::<message>*/ {
+  /*::
+  $type: "Signal.Mailbox";
+  signal: Signal<message>;
+  address: Address<message>;
+  */
+  constructor(message/*:message*/) {
+    this.signal = new Input(message)
+    this.address = Input.Address(this.signal)
+  }
+}
+Inbox.prototype.$type = "Signal.Mailbox"
+
+export const mailbox = /*::<message>*/
+  (message/*:message*/)/*:Mailbox<message>*/ =>
+  new Inbox(message)
+
+
+const Forward = /*::<a,b>*/
+  ( address/*:Address<b>*/
+  , tag/*:(a:a)=>b*/
+  )/*:Address<a>*/ => {
+    const forward = (message/*:a*/) => address(tag(message))
+    forward.to = address
+    forward.tag = tag
+    return forward
+  }
+
+if (global['reflex/address'] == null) {
+  global['reflex/address'] = 0
+}
+
+// Create a new address. This address will tag each message it receives and then
+// forward it along to the given address.
+// Example:
+//
+// const Remove = target => {type: "Remove", target}
+// removeAddress = forward(address, Remove)
+//
+// Above example created `removeAddress` tags each message with `Remove` tag
+// before forwarding them to a general `address`.
+export const forward = /*::<a, b>*/
+  ( address/*:Address<a>*/
+  , tag/*:Translate<b, a>*/
+  )/*:Address<b>*/ => {
+    // Genrate ID for each address that has a forwarding addresses so that
+    // forwarding addresses could be cached by that id and a tag-ing function.
+    const id = address.id != null ? address.id :
+               (address.id = global['reflex/address']++);
+    const key = `reflex/address/${id}`
+
+    return tag[key] || (tag[key] = Forward(address, tag))
+  }
+
+
+export const reductions = /*::<state, input>*/
+  ( step/*:Reducer<state, input>*/
+  , state/*:state*/
+  , input/*:Signal<input>*/
+  )/*:Signal<state>*/ => {
+    const output = new Input(state)
+    input.connect(forward(Input.Address(output),
+                          value => step(output.value, value)))
+  return output
+}
+
+export const map = /*::<a, b>*/
+  ( f/*:Translate<a, b>*/
+  , input/*:Signal<a>*/
+  )/*:Signal<b>*/ => {
+    const output = new Input(f(input.value))
+    input.connect(forward(Input.Address(output), f))
+    return output
+  }

--- a/src/task.js
+++ b/src/task.js
@@ -1,0 +1,432 @@
+/* @flow */
+
+/*::
+import type {Time, ThreadID} from "./task"
+import type {Address} from "./signal"
+
+export type {ThreadID, Time}
+*/
+
+export class Task /*::<x, a>*/ {
+  static create /*::<x, a>*/(execute/*:(succeed:(a:a) => void, fail:(x:x) => void) => void*/)/*:Task<x, a>*/ {
+    return new Task(execute)
+  }
+
+  static future /*::<x, a>*/(request/*:() => Promise<a>*/)/*:Task<x, a>*/ {
+    console.warn('Task.future is deprecated API use Task.create instead')
+    return new Future(request)
+  }
+
+  static succeed /*::<x, a>*/(value/*:a*/)/*:Task<x, a>*/ {
+    return new Succeed(value)
+  }
+
+  static fail /*::<x, a>*/ (error/*:x*/)/*:Task<x, a>*/ {
+    return new Fail(error)
+  }
+
+  static spawn /*::<x, y, a>*/ (task/*:Task<x, a>*/)/*:Task<y, ThreadID>*/ {
+    return new Spawn(task)
+  }
+
+
+  static sleep /*::<x>*/ (time:Time)/*:Task<x, void>*/ {
+    return new Sleep(time)
+  }
+
+  static send /*::<x, a>*/ (address/*:Address<a>*/, message/*:a*/)/*:Task<x, void>*/ {
+    return new Send(address, message)
+  }
+
+  static fork /*::<x, a>*/(task/*:Task<x, a>*/, onSucceed/*:(a:a) => void*/, onFail/*:(x:x) => void*/)/*:void*/ {
+    run(new Running(task), onSucceed, onFail)
+  }
+
+  /*::
+  execute: (succeed:(a:a) => void, fail:(x:x) => void) => void;
+  */
+  constructor(execute/*:(succeed:(a:a) => void, fail:(x:x) => void) => void*/) {
+    this.execute = execute
+  }
+  chain /*::<b>*/(next/*:(a:a) => Task<x,b>*/)/*:Task<x, b>*/ {
+    return new Chain(this, next)
+  }
+  map /*::<b>*/(f/*:(input:a) => b*/)/*:Task<x, b>*/ {
+    return new Map(this, f)
+  }
+  capture /*::<y>*/(handle/*:(error:x) => Task<y, a>*/)/*:Task<y, a>*/ {
+    return new Capture(this, handle)
+  }
+  format /*::<y>*/ (f/*:(input:x) => y*/)/*:Task<y, a>*/ {
+    return new Format(this, f)
+  }
+  fork(succeed/*:(a:a) => void*/, fail/*:(x:x) => void*/)/*:void*/ {
+    this.execute
+    ( succeed
+    , fail
+    )
+  }
+}
+
+
+
+class Succeed /*::<x,a>*/ extends Task /*::<x, a>*/ {
+  /*::
+  value: a;
+  */
+  constructor(value/*:a*/) {
+    super(Succeed.prototype.fork)
+    this.value = value
+  }
+  fork(succeed/*:(a:a) => void*/, fail/*:(x:x) => void*/)/*:void*/ {
+    succeed(this.value)
+  }
+}
+
+class Fail /*::<x, a>*/ extends Task /*::<x, a>*/ {
+  /*::
+  error: x;
+  */
+  constructor(error/*:x*/) {
+    super(Fail.prototype.fork)
+    this.error = error
+  }
+  fork(succeed/*:(a:a) => void*/, fail/*:(x:x) => void*/)/*:void*/ {
+    fail(this.error)
+  }
+}
+
+class Sleep /*::<x, a:void>*/ extends Task /*::<x, void>*/ {
+  /*::
+  time: Time;
+  */
+  constructor(time/*:Time*/) {
+    super(Sleep.prototype.fork)
+    this.time = time
+  }
+  fork(succeed/*:(a:a) => void*/, fail/*:(x:x) => void*/)/*:void*/ {
+    setTimeout(succeed, this.time, void(0))
+  }
+}
+
+let threadID = 0
+class Spawn /*::<x, y, a>*/ extends Task /*::<y, ThreadID>*/ {
+  /*::
+  task: Task<x, a>;
+  */
+  constructor(task/*:Task<x, a>*/) {
+    super(Spawn.prototype.fork)
+    this.task = task
+  }
+  fork(succeed/*:(a:ThreadID) => void*/, fail/*:(x:y) => void*/)/*:void*/ {
+    Promise
+    .resolve(null)
+    .then(_ => Task.fork(this.task, noop, noop))
+
+    succeed(++threadID)
+  }
+}
+
+class Send /*::<x, a>*/ extends Task /*::<x, void>*/ {
+  /*::
+  message: a;
+  address: Address<a>;
+  */
+  constructor(address/*:Address<a>*/, message/*:a*/) {
+    super(Send.prototype.fork)
+    this.message = message
+    this.address = address
+  }
+  fork(succeed/*:(a:void) => void*/, fail/*:(x:x) => void*/)/*:void*/ {
+    succeed(void(this.address(this.message)))
+  }
+}
+
+class Future /*::<x, a>*/ extends Task/*::<x, a>*/ {
+  /*::
+  request: () => Promise<a>;
+  */
+  constructor(request/*:() => Promise<a>*/) {
+    super(Future.prototype.fork)
+    this.request = request
+  }
+  fork(succeed/*:(a:a) => void*/, fail/*:(x:x) => void*/)/*:void*/ {
+    this.request().then(succeed, fail)
+  }
+}
+
+class Chain /*::<x, a, b>*/ extends Task/*::<x, a>*/ {
+  /*::
+  task: Task<x, b>;
+  next: (input:b) => Task<x, a>;
+  */
+  constructor(task/*:Task<x, b>*/, next/*:(input:b) => Task<x, a>*/) {
+    super(Chain.prototype.fork)
+    this.task = task
+    this.next = next
+  }
+  fork(succeed/*:(value:a) => void*/, fail/*:(error:x) => void*/)/*:void*/ {
+    this.task.fork
+    ( value => this.next(value).fork(succeed, fail)
+    , fail
+    )
+  }
+}
+
+class Map /*::<x, a, b>*/ extends Task/*::<x, b>*/ {
+  /*::
+  task: Task<x, a>;
+  f: (input:a) => b;
+  */
+  constructor(task/*:Task<x, a>*/, f/*:(input:a) => b*/) {
+    super(Map.prototype.fork)
+    this.task = task
+    this.f = f
+  }
+  fork(succeed/*:(value:b) => void*/, fail/*:(error:x) => void*/)/*:void*/ {
+    this.task.fork
+    ( value => succeed(this.f(value))
+    , fail
+    )
+  }
+}
+
+class Capture/*::<x, y, a>*/extends Task/*::<y, a>*/{
+  /*::
+  task: Task<x, a>;
+  handle: (error:x) => Task<y, a>;
+  */
+  constructor(task/*:Task<x, a>*/, handle/*:(error:x) => Task<y, a>*/) {
+    super(Capture.prototype.fork)
+    this.task = task
+    this.handle = handle
+  }
+  fork(succeed/*:(value:a) => void*/, fail/*:(error:y) => void*/)/*:void*/ {
+    this.task.fork
+    ( succeed
+    , error => this.handle(error).fork(succeed, fail)
+    )
+  }
+}
+
+class Format/*::<x, y, a>*/extends Task/*::<y, a>*/{
+  /*::
+  task: Task<x, a>;
+  f: (input:x) => y;
+  */
+  constructor(task/*:Task<x, a>*/, f/*:(input:x) => y*/) {
+    super(Format.prototype.fork)
+    this.task = task
+    this.f = f
+  }
+  fork(succeed/*:(value:a) => void*/, fail/*:(error:y) => void*/)/*:void*/ {
+    this.task.fork
+    ( succeed
+    , error => fail(this.f(error))
+    )
+  }
+}
+
+class Deferred /*::<x, a>*/ extends Task /*::<x, a>*/ {
+  /*::
+  result: ?Task<x, a>;
+  */
+  constructor() {
+    super(Deferred.prototype.fork)
+  }
+  resume(task/*:Task<x, a>*/)/*:void*/ {
+    if (this.result != null) {
+      throw Error('Deferred task can only be resumed once')
+    }
+    this.result = task
+  }
+  fork(succeed/*:(a:a) => void*/, fail/*:(x:x) => void*/)/*:void*/ {
+    throw Error('Forking defferred task is not allowed')
+  }
+}
+
+const noop = () => void(0)
+
+class Running /*::<x, a>*/ {
+  /*::
+  task: Task<x, a>;
+  */
+  constructor /*::<x, a>*/(task/*:Task<x, a>*/) {
+    this.task = task
+  }
+}
+
+class Done /*::<x, a>*/ {
+  /*::
+  task: Task<x, a>;
+  */
+  constructor(task/*:Succeed<x, a> | Fail<x, a>*/) {
+    this.task = task
+  }
+}
+
+class Blocked /*::<x, a>*/ {
+  /*::
+  task: Task<x, a>;
+  */
+  constructor(task/*:Task<x, a>*/) {
+    this.task = task
+  }
+}
+
+/*::
+type Routine <x, a>
+  = Blocked <x, a>
+  | Done <x, a>
+  | Running <x, a>
+*/
+
+const run = /*::<x, a>*/
+  ( root/*:Routine<x, a>*/
+  , succeed/*:(value:a) => void*/
+  , fail/*:(error:x) => void*/
+  )/*:void*/ =>
+  {
+    let routine = new Running(root.task)
+    while (routine instanceof Running) {
+      routine = step(root, routine.task, succeed, fail)
+    }
+
+    if (routine instanceof Blocked) {
+      root.task = routine.task
+    }
+
+    if (routine instanceof Done) {
+      const task = routine.task
+      if (task instanceof Succeed) {
+        succeed(task.value)
+      }
+      else if (task instanceof Fail) {
+        fail(task.error)
+      }
+      else {
+        throw Error('Task end up in an invalid state')
+      }
+    }
+  }
+
+const step = /*::<x, y, a, b>*/
+  ( root/*:Routine*/
+  , task/*:Task<x, a>*/
+  , succeed/*:(value:b) => void*/
+  , fail/*:(error:y) => void*/
+  )/*:Routine*/ =>
+  {
+    if (task instanceof Succeed) {
+      return new Done(task)
+    }
+    else if (task instanceof Fail) {
+      return new Done(task)
+    }
+    else if (task instanceof Deferred) {
+      if (task.result != null) {
+        return new Running(task.result)
+      }
+      else {
+        throw new Error('Blocked routine should not be resumed until blocking task is complete')
+      }
+    }
+    else if (
+      task instanceof Chain ||
+      task instanceof Map ||
+      task instanceof Capture ||
+      task instanceof Format
+    )
+    {
+      let routine = new Running(task.task)
+      while (routine instanceof Running) {
+        routine = step(root, routine.task, succeed, fail)
+      }
+
+      if (routine instanceof Done) {
+        const active = routine.task
+
+        if (active instanceof Succeed) {
+          if (task instanceof Chain) {
+            return new Running(task.next(active.value))
+          }
+          else if (task instanceof Map) {
+            return new Done(new Succeed(task.f(active.value)))
+          }
+          else {
+            return routine
+          }
+        }
+        else if (active instanceof Fail) {
+          if (task instanceof Capture) {
+            return new Running(task.handle(active.error))
+          }
+          else if (task instanceof Format) {
+            return new Done(new Fail(task.f(active.error)))
+          }
+          else {
+            return routine
+          }
+        }
+        else {
+          return routine
+        }
+      }
+      else if (routine instanceof Blocked) {
+        if (task instanceof Chain) {
+          return new Blocked(new Chain(routine.task, task.next))
+        }
+        else if (task instanceof Capture) {
+          return new Blocked(new Capture(routine.task, task.handle))
+        }
+        else if (task instanceof Map) {
+          return new Blocked(new Map(routine.task, task.f))
+        }
+        else if (task instanceof Format) {
+          return new Blocked(new Format(routine.task, task.f))
+        }
+        else {
+          return routine
+        }
+      }
+      else {
+        return routine
+      }
+    }
+    else {
+      let isBlocked = false
+      let isResumed = false
+      const deferred = new Deferred()
+
+      task.fork
+      ( value => {
+          if (!isResumed) {
+            isResumed = true
+            deferred.resume(new Succeed(value))
+            if (isBlocked) {
+              run(root, succeed, fail)
+            }
+          }
+        }
+      , error => {
+          if (!isResumed) {
+            isResumed = true
+            deferred.resume(new Fail(error))
+            if (isBlocked) {
+              run(root, succeed, fail)
+            }
+          }
+        }
+      )
+
+      isBlocked = !isResumed
+
+      const routine =
+        ( deferred.result != null
+        ? new Running(deferred.result)
+        : new Blocked(deferred)
+        )
+
+      return routine
+    }
+  }


### PR DESCRIPTION
@tschneidereit Any feedback of possible bottlenecks would be great.
### [`application.js`](https://github.com/Gozala/reflex/pull/46/files#diff-a418f1fe004a566b539ca636b9c906f1)

I would start reading from this file. The `start` function is what wires everything up. `beginner` is just a functions that transform trivial app configuration the the one that `start` expects.

Configuration passed to `start` is expected to contain `flags` (which some data that is just forwarded to) `init` function, `update`  and `view` functions.
- `init` supposed to construct initial state and request any kind of side effects (usually io task) to be performed to bootstrap. There for it returns `[model, fx]` pair.
- Initial `model` then gets rendered via `view(model, address)`. Where `model` is whatever the immediate state of the app is and `address` is a function that could be used to trigger more updates. Any user just passes `action` describing it to the `address`. In turn received `action` triggers `update(model, action)` that supposed to return `[model, fx]` pair like `init` did. View itself returns virtual-dom describing the application UI.

One semi-confusing thing is that functions used to build virtual-dom tree  (see `dom.js`) provide implementations of `node`, `text` and `thunk` that either just delegate to same named functions on mysterious `driver` or just return boxes that do that on `.force()`. This is to facilitate swappable drivers for rendering. The way it works is that after `update` returned a `[model, fx]` new view is created as `root(view, model, address)` then if driver is plugged it will update it's internal state with that `VirtualRoot`  instance & schedule an animation frame & once animation frame is triggered `VirtualRoot` instances `renderWith` is invoked with actual virtual-dom implementation of that driver. So at the end of the day `node`, `text` and `thunk` just delegate to `driver.node`, `driver.text` and `driver.thunk` that does rendering. Only exception is if fragment of the virtual-tree is created outside of the `view` function (for example reusable static chunk is defined outside of view function) in such case `LazyNode` and friends are created, which are then `.force()`-ed as they get included inside actual virtual-dom tree.
### `signal.js`

Provides simplistic implementation of FRP signals, if not familiar with FRP think of it as streams. Above mentioned `start` returns `view`, `task` and `model` signals. Drivers are plugged by subscribing to a signal. So in case of renderer, we subscribe to the `view` signal and every time we receive new value we schedule animation frame and update internal ref of what needs to be rendered. `task` signal similarly is a signal for requested effects (that `init` and `update` return). That also works with a driver, which performs those tasks and feeds results via actions into `address`.
### `task.js`

Provides API very similar to `Promise`, primary difference is that it that it's not an eventual result of a computation but rather an eventual computation that driver can execute if so choses. Primary purpose of tasks is to do IO like XHR or even things like mutate DOM.
### `effects.js`

This is kind of facility do to wiring / routing of tasks. When I mentioned that `init` / `update` return `[model, fx]` the `fx` part was instance of `Effects`. `Effects` just allow you to tag results of tasks they wrap, or batch several of them together. Or just imply no effects via `Effects.none`.
